### PR TITLE
Alex/mat44 transpose invert returns

### DIFF
--- a/sm/mat22
+++ b/sm/mat22
@@ -112,9 +112,9 @@ namespace sm
         }
 
         //! Transpose this matrix
-        void transpose() noexcept
+        mat22<F> transpose() noexcept
         {
-            mat22<F> rtn = this->mat;
+            mat22<F> rtn = *this;
             F a = this->mat[2];
             rtn[2] = this->mat[1];
             rtn[1] = a;

--- a/sm/mat22
+++ b/sm/mat22
@@ -104,11 +104,22 @@ namespace sm
         }
 
         //! Transpose this matrix
-        void transpose() noexcept
+        void transpose_inplace() noexcept
         {
             F a = this->mat[2];
             this->mat[2] = this->mat[1];
             this->mat[1] = a;
+        }
+
+        //! Transpose this matrix
+        void transpose() noexcept
+        {
+            mat22<F> rtn = this->mat;
+            F a = this->mat[2];
+            rtn[2] = this->mat[1];
+            rtn[1] = a;
+
+            return rtn;
         }
 
         //! Transpose the matrix @matrx, returning the transposed version.
@@ -137,6 +148,19 @@ namespace sm
         {
             sm::vec<F, 4> adj = { this->mat[3], -this->mat[1], -this->mat[2], this->mat[0] };
             return adj;
+        }
+
+        //! Turn this matrix into its inverse
+        void inverse_inplace() noexcept
+        {
+            F det = this->determinant();
+            if (det == 0) {
+                std::cout << "NB: The transform matrix has no inverse (determinant is 0)" << std::endl;
+                *this.mat.zero();
+            } else {
+                *this.mat = this->adjugate();
+                *this *= (F{1}/det);
+            }
         }
 
         //! Return the inverse matrix

--- a/sm/mat33
+++ b/sm/mat33
@@ -116,7 +116,7 @@ namespace sm
         }
 
         //! Transpose this matrix
-        void transpose() noexcept
+        void transpose_inplace() noexcept
         {
             std::array<F, 3> a;
             a[0] = this->mat[1];
@@ -130,6 +130,26 @@ namespace sm
             this->mat[3] = a[0];
             this->mat[6] = a[1];
             this->mat[7] = a[2];
+        }
+
+        //! Return this matrix transposed
+        void mat33<F> transpose() noexcept
+        {
+            mat33<F> rtn = this->mat;
+            std::array<F, 3> a;
+            a[0] = this->mat[1];
+            a[1] = this->mat[2];
+            a[2] = this->mat[5];
+
+            rtn[1] = this->mat[3];
+            rtn[2] = this->mat[6];
+            rtn[5] = this->mat[7];
+
+            rtn[3] = a[0];
+            rtn[6] = a[1];
+            rtn[7] = a[2];
+
+            return rtn;
         }
 
         //! Transpose the matrix @matrx, returning the transposed version.
@@ -250,6 +270,19 @@ namespace sm
                 std::cout <<"  "<< cofac[2]<<" , "<<cofac[5]<<" , "<<cofac[8]<<" ;\n";
             }
             return cofac;
+        }
+
+        //! Turn this matrix in to its inverse
+        void inverse_inplace() noexcept
+        {
+            F det = this->determinant();
+            if (det == F{0}) {
+                std::cout << "NB: The transform matrix has no inverse (determinant is 0)" << std::endl;
+                *this.mat.fill (F{0});
+            } else {
+                *this.mat = this->adjugate();
+                *this *= (F{1}/det);
+            }
         }
 
         //! Return the inverse matrix

--- a/sm/mat33
+++ b/sm/mat33
@@ -133,9 +133,9 @@ namespace sm
         }
 
         //! Return this matrix transposed
-        void mat33<F> transpose() noexcept
+        mat33<F> transpose() noexcept
         {
-            mat33<F> rtn = this->mat;
+            mat33<F> rtn = *this;
             std::array<F, 3> a;
             a[0] = this->mat[1];
             a[1] = this->mat[2];

--- a/sm/mat44
+++ b/sm/mat44
@@ -1220,7 +1220,7 @@ namespace sm
         //! Return the matrix transposed
         constexpr mat44<F> transpose() noexcept
         {
-            mat44<F> rtn = this->mat;
+            mat44<F> rtn = *this;
             std::array<F, 6> a;
             a[0] = this->mat[4];
             a[1] = this->mat[8];

--- a/sm/mat44
+++ b/sm/mat44
@@ -600,7 +600,7 @@ namespace sm
          * 2. Obtain the adjugate matrix
          * 3. Get the inverse by multiplying 1/determinant by the adjugate
          */
-        constexpr mat44<F> inverse() noexcept
+        constexpr mat44<F> inverse() noexcept // check this with eigen
         {
             F det = this->determinant();
             mat44<F> rtn;
@@ -612,6 +612,29 @@ namespace sm
                 rtn *= (F{1}/det);
             }
             return rtn;
+        }
+
+        /*!
+         * Turn the matrix into its inverse.
+         *
+         * Implement inversion using determinant method. inverse is (1/det) x adjugate
+         * matrix.
+         *
+         * 1. Compute determinant of this->mat (if 0, then there's no inverse)
+         * 2. Obtain the adjugate matrix
+         * 3. Get the inverse by multiplying 1/determinant by the adjugate
+         */
+        constexpr void inverse_inplace() noexcept // check this with eigen
+        {
+            F det = this->determinant();
+            mat44<F> rtn;
+            if (det == F{0}) {
+                // The transform matrix has no inverse (determinant is 0)
+                *this.mat.fill (F{0});
+            } else {
+                *this.mat = this->adjugate();
+                *this *= (F{1}/det);
+            }
         }
 
         /*!
@@ -1169,7 +1192,7 @@ namespace sm
         }
 
         //! Transpose this matrix
-        constexpr void transpose() noexcept
+        constexpr void transpose_inplace() noexcept
         {
             std::array<F, 6> a;
             a[0] = this->mat[4];
@@ -1192,6 +1215,35 @@ namespace sm
             this->mat[6] = a[2];  // mat[9]
             this->mat[7] = a[4];  // mat[13]
             this->mat[11] = a[5]; // mat[14]
+        }
+
+        //! Return the matrix transposed
+        constexpr mat44<F> transpose() noexcept
+        {
+            mat44<F> rtn = this->mat;
+            std::array<F, 6> a;
+            a[0] = this->mat[4];
+            a[1] = this->mat[8];
+            a[2] = this->mat[9];
+            a[3] = this->mat[12];
+            a[4] = this->mat[13];
+            a[5] = this->mat[14];
+
+            rtn[4] = this->mat[1];
+            rtn[8] = this->mat[2];
+            rtn[9] = this->mat[6];
+            rtn[12] = this->mat[3];
+            rtn[13] = this->mat[7];
+            rtn[14] = this->mat[11];
+
+            rtn[1] = a[0];  // mat[4]
+            rtn[2] = a[1];  // mat[8]
+            rtn[3] = a[3];  // mat[12]
+            rtn[6] = a[2];  // mat[9]
+            rtn[7] = a[4];  // mat[13]
+            rtn[11] = a[5]; // mat[14]
+
+            return rtn;
         }
 
         //! Transpose the matrix @matrx, returning the transposed version.

--- a/tests/testMatrix22.cpp
+++ b/tests/testMatrix22.cpp
@@ -55,7 +55,7 @@ int main()
     std::cout << "mult1 * mult2.mat =\n" << mult3alt << std::endl;
 
     sm::mat22<float> mult2_t = mult2;
-    mult2_t.transpose();
+    mult2_t.transpose_inplace();
     std::cout << "mult2 transposed =\n" << mult2_t << std::endl;
 
     if (mult3.mat[0] != 8 || mult3.mat[1] != 17

--- a/tests/testMatrix33.cpp
+++ b/tests/testMatrix33.cpp
@@ -83,7 +83,7 @@ int main()
     std::cout << "mult1 * mult2.mat =\n" << mult3alt << std::endl;
 
     sm::mat33<float> mult2_t = mult2;
-    mult2_t.transpose();
+    mult2_t.transpose_inplace();
     std::cout << "mult2 transposed =\n" << mult2_t << std::endl;
 
     if (mult3.mat[0] != 120


### PR DESCRIPTION
Previously the behaviour of transpose and inverse was inconsistent.  The transpose function in the matrix classes mat22, mat33 and mat44 did a transpose in place, whereas the inverse function returned the inverse of matrix.
Following this PR these matrix classes now have `transpose_inplace` and `inverse_inplace`, as well as `transpose` and `inverse` functions which return modified matricies, leaving the matrix itself unchanged.    