### PR TITLE
fix clang-cl warning for /constexpr:steps500000000

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 project(maths)
 
 message(STATUS "Install prefix: ${CMAKE_INSTALL_PREFIX}")
@@ -23,13 +23,17 @@ endif()
 if (APPLE)
   set(CMAKE_CXX_FLAGS "-Wall -g -O3")
 else()
-  if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
+  if(CMAKE_CXX_COMPILER_ID MATCHES MSVC OR CMAKE_CXX_COMPILER_FRONTEND_VARIANT MATCHES MSVC)
     # Set flags for Windows.
     # -DNOMINMAX to prefer std::min and std::max
     # /EHsc required for use of exceptions
     # /Zc:__cplusplus ensures __cplusplus define does not lie
     # /constexpr:steps is equivalent to -fconstexpr-steps or -fconstexpr-ops-limit
-    set(CMAKE_CXX_FLAGS "-DNOMINMAX /EHsc /Zc:__cplusplus /constexpr:steps500000000")
+    if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
+      set(CMAKE_CXX_FLAGS "-DNOMINMAX /EHsc /Zc:__cplusplus /constexpr:steps500000000")
+    else()
+      set(CMAKE_CXX_FLAGS "-DNOMINMAX /EHsc /Zc:__cplusplus")
+    endif()
   elseif(CMAKE_CXX_COMPILER_ID MATCHES Intel)
     # To use Intel compiler, you can call cmake as: `cmake -DCMAKE_CXX_COMPILER=icpc ..` or `CXX=icpc cmake ..`
     message(WARNING "Intel compiler has not been tested for some time")


### PR DESCRIPTION
on windows, there are `Clang GNU CLI` and `CLang MSVC CLI`, the `Clang GNU CLI` works fine, but `CLang MSVC CLI` doesn't have all the option as MSVC, it will generate these warnings:

```c++
[build] [18/178   0% :: 0.880] Building CXX object tests\CMakeFiles\testarray_asmapkey.dir\testarray_asmapkey.cpp.obj
[build] clang-cl: warning: argument unused during compilation: '/constexpr:steps500000000' [-Wunused-command-line-argument]
[build] [19/178   1% :: 1.066] Building CXX object tests\CMakeFiles\testQuat_constexpr.dir\testQuat_constexpr.cpp.obj
[build] clang-cl: warning: argument unused during compilation: '/constexpr:steps500000000' [-Wunused-command-line-argument]
[build] [20/178   1% :: 1.079] Building CXX object tests\CMakeFiles\testvec_asunordmapkey.dir\testvec_asunordmapkey.cpp.obj
[build] clang-cl: warning: argument unused during compilation: '/constexpr:steps500000000' [-Wunused-command-line-argument]
```

see https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_FRONTEND_VARIANT.html, I update the cmake version to >= 3.14